### PR TITLE
Feature: add tuple constraint.

### DIFF
--- a/include/garlic/module.h
+++ b/include/garlic/module.h
@@ -350,6 +350,7 @@ namespace garlic {
         {"field", &FieldConstraint<Destination>::parse},
         {"any", &AnyConstraint<Destination>::parse},
         {"list", &ListConstraint<Destination>::parse},
+        {"tuple", &TupleConstraint<Destination>::parse},
       };
 
       if (value.is_string()) {

--- a/tests/data/special_constraints/module.yaml
+++ b/tests/data/special_constraints/module.yaml
@@ -19,6 +19,30 @@ fields:
                     items: [UserId, User]
               message: List of user ids or objects expected.
 
+    GeoLocation:
+        constraints:
+            - type: tuple
+              items: [string, double, double]
+              message: Expected [name, lat, long]
+
+    StateField:
+        constraints:
+            - type: string
+            - type: range
+              min: 2
+              max: 2
+
+    CityTuple:
+        constraints:
+            - type: tuple
+              items: [string, StateField]
+
+    UnixCommand:
+        constraints:
+            - type: tuple
+              items: [string]
+              strict: false
+
 models:
     User:
         fields:
@@ -34,3 +58,9 @@ models:
     ListTest:
         fields:
             users: UserList
+
+    TupleTest:
+        fields:
+            city: CityTuple
+            location: GeoLocation
+            command: UnixCommand

--- a/tests/data/special_constraints/tuple_bad1.json
+++ b/tests/data/special_constraints/tuple_bad1.json
@@ -1,0 +1,5 @@
+{
+    "city": ["Any String", "California"],
+    "location": ["home", 0.0, 0.0],
+    "command": ["env"]
+}

--- a/tests/data/special_constraints/tuple_bad2.json
+++ b/tests/data/special_constraints/tuple_bad2.json
@@ -1,0 +1,5 @@
+{
+    "city": ["New York", "NY"],
+    "location": [0.0, 0.0, 1.0],
+    "command": ["env"]
+}

--- a/tests/data/special_constraints/tuple_bad3.json
+++ b/tests/data/special_constraints/tuple_bad3.json
@@ -1,0 +1,5 @@
+{
+    "city": ["New York", "NY"],
+    "location": [0.0],
+    "command": ["env"]
+}

--- a/tests/data/special_constraints/tuple_bad4.json
+++ b/tests/data/special_constraints/tuple_bad4.json
@@ -1,0 +1,5 @@
+{
+    "city": ["New York", "NY"],
+    "location": ["home", 0.0, 0.0],
+    "command": [0, "env"]
+}

--- a/tests/data/special_constraints/tuple_bad5.json
+++ b/tests/data/special_constraints/tuple_bad5.json
@@ -1,0 +1,5 @@
+{
+    "city": ["New York", "NY"],
+    "location": ["home", 0.0, 0.0],
+    "command": []
+}

--- a/tests/data/special_constraints/tuple_bad6.json
+++ b/tests/data/special_constraints/tuple_bad6.json
@@ -1,0 +1,5 @@
+{
+    "city": ["New York", "NY"],
+    "location": ["home", 0.0, 0.0, 1.0],
+    "command": ["env"]
+}

--- a/tests/data/special_constraints/tuple_good1.json
+++ b/tests/data/special_constraints/tuple_good1.json
@@ -1,0 +1,5 @@
+{
+    "city": ["New York", "NY"],
+    "location": ["home", 12.10, -10.20],
+    "command": ["sh", "-c", "echo", "test"]
+}

--- a/tests/data/special_constraints/tuple_good2.json
+++ b/tests/data/special_constraints/tuple_good2.json
@@ -1,0 +1,5 @@
+{
+    "city": ["Any String", "CA"],
+    "location": ["home", 0.0, 0.0],
+    "command": ["env"]
+}

--- a/tests/test_constraints.cpp
+++ b/tests/test_constraints.cpp
@@ -33,7 +33,22 @@ TEST(Constraints, ListConstraint) {
 
   load_libyaml_module(module, "data/special_constraints/module.yaml");
 
-  assert_jsonfile_valid(module, "ListTest", "data/special_constraints/list_good1.json", true);
-  assert_jsonfile_invalid(module, "ListTest", "data/special_constraints/list_bad1.json", true);
-  assert_jsonfile_invalid(module, "ListTest", "data/special_constraints/list_bad2.json", true);
+  assert_jsonfile_valid(module, "ListTest", "data/special_constraints/list_good1.json");
+  assert_jsonfile_invalid(module, "ListTest", "data/special_constraints/list_bad1.json");
+  assert_jsonfile_invalid(module, "ListTest", "data/special_constraints/list_bad2.json");
+}
+
+TEST(Constraints, TupleConstraint) {
+  auto module = Module<JsonView>();
+
+  load_libyaml_module(module, "data/special_constraints/module.yaml");
+
+  assert_jsonfile_valid(module, "TupleTest", "data/special_constraints/tuple_good1.json", true);
+  assert_jsonfile_valid(module, "TupleTest", "data/special_constraints/tuple_good2.json", true);
+  assert_jsonfile_invalid(module, "TupleTest", "data/special_constraints/tuple_bad1.json", true);
+  assert_jsonfile_invalid(module, "TupleTest", "data/special_constraints/tuple_bad2.json", true);
+  assert_jsonfile_invalid(module, "TupleTest", "data/special_constraints/tuple_bad3.json", true);
+  assert_jsonfile_invalid(module, "TupleTest", "data/special_constraints/tuple_bad4.json", true);
+  assert_jsonfile_invalid(module, "TupleTest", "data/special_constraints/tuple_bad5.json", true);
+  assert_jsonfile_invalid(module, "TupleTest", "data/special_constraints/tuple_bad6.json", true);
 }


### PR DESCRIPTION
# Tuple Constraint

A newly added constraint allows to read an indexed tuple.

```yaml
fields:
    ShellCommand:
        type: tuple
        items: [string]
        strict: false

    Point3D:
        type: tuple
        items: [double, double, double]

models:
    CommandDescription:
        fields:
            command: ShellCommand

    LocationChangedEvent:
        fields:
            origin: Point3D
            destination: Point3D
```
