### PR TITLE
Feature: Map Constraint

### DIFF
--- a/include/garlic/module.h
+++ b/include/garlic/module.h
@@ -351,6 +351,7 @@ namespace garlic {
         {"any", &AnyConstraint<Destination>::parse},
         {"list", &ListConstraint<Destination>::parse},
         {"tuple", &TupleConstraint<Destination>::parse},
+        {"map", &MapConstraint<Destination>::parse},
       };
 
       if (value.is_string()) {

--- a/tests/data/special_constraints/map_bad1.json
+++ b/tests/data/special_constraints/map_bad1.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {
+        "label": 12
+    },
+    "string_to_any": {},
+    "string_to_bool": {}
+}

--- a/tests/data/special_constraints/map_bad2.json
+++ b/tests/data/special_constraints/map_bad2.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {},
+    "string_to_any": {
+        "some_random_value": "test"
+    },
+    "string_to_bool": {}
+}

--- a/tests/data/special_constraints/map_bad3.json
+++ b/tests/data/special_constraints/map_bad3.json
@@ -1,0 +1,7 @@
+{
+    "_meta": {},
+    "string_to_any": {},
+    "string_to_bool": {
+        "something": 12
+    }
+}

--- a/tests/data/special_constraints/map_good1.json
+++ b/tests/data/special_constraints/map_good1.json
@@ -1,0 +1,15 @@
+{
+    "_meta": {
+        "field1":" value2"
+    },
+    "string_to_any": {
+        "field1": "String",
+        "field2": 12,
+        "field3": 1.1,
+        "field4": true
+    },
+    "string_to_bool": {
+        "field1": true,
+        "field2": false
+    }
+}

--- a/tests/data/special_constraints/module.yaml
+++ b/tests/data/special_constraints/module.yaml
@@ -43,6 +43,25 @@ fields:
               items: [string]
               strict: false
 
+    MetaField:
+        constraints:
+            - type: map
+              key: string
+              value: string
+
+    StringToAny:
+        constraints:
+            - type: map
+              key:
+                  type: regex
+                  pattern: field\d*
+
+    StringToBool:
+        constraints:
+            - type: map
+              key: string
+              value: bool
+
 models:
     User:
         fields:
@@ -64,3 +83,9 @@ models:
             city: CityTuple
             location: GeoLocation
             command: UnixCommand
+
+    MapTest:
+        fields:
+            _meta: MetaField
+            string_to_any: StringToAny
+            string_to_bool: StringToBool

--- a/tests/test_constraints.cpp
+++ b/tests/test_constraints.cpp
@@ -52,3 +52,14 @@ TEST(Constraints, TupleConstraint) {
   assert_jsonfile_invalid(module, "TupleTest", "data/special_constraints/tuple_bad5.json");
   assert_jsonfile_invalid(module, "TupleTest", "data/special_constraints/tuple_bad6.json");
 }
+
+TEST(Constraints, MapConstraint) {
+  auto module = Module<JsonView>();
+
+  load_libyaml_module(module, "data/special_constraints/module.yaml");
+
+  assert_jsonfile_valid(module, "MapTest", "data/special_constraints/map_good1.json");
+  assert_jsonfile_invalid(module, "MapTest", "data/special_constraints/map_bad1.json");
+  assert_jsonfile_invalid(module, "MapTest", "data/special_constraints/map_bad2.json");
+  assert_jsonfile_invalid(module, "MapTest", "data/special_constraints/map_bad3.json");
+}


### PR DESCRIPTION
# Map Constraint

This PR introduces a new constraint, reading maps.

It is optional to place constraints on `key` and `value` attributes.

```yaml
fields:
    UserToAccount:
        constraints:
            - type: map
              key: User
              value: Account
```
