### PR TITLE
Feature: All Constraint

### DIFF
--- a/include/garlic/module.h
+++ b/include/garlic/module.h
@@ -349,6 +349,7 @@ namespace garlic {
         {"range", &RangeConstraint<Destination>::parse},
         {"field", &FieldConstraint<Destination>::parse},
         {"any", &AnyConstraint<Destination>::parse},
+        {"all", &AllConstraint<Destination>::parse},
         {"list", &ListConstraint<Destination>::parse},
         {"tuple", &TupleConstraint<Destination>::parse},
         {"map", &MapConstraint<Destination>::parse},

--- a/tests/data/special_constraints/all_bad1.json
+++ b/tests/data/special_constraints/all_bad1.json
@@ -1,0 +1,4 @@
+{
+    "hide_constraint": {"some_key": "not a list"},
+    "hide_constraint_precise": {"some_key": "not a list"}
+}

--- a/tests/data/special_constraints/all_bad2.json
+++ b/tests/data/special_constraints/all_bad2.json
@@ -1,0 +1,4 @@
+{
+    "hide_constraint": {"some_key": [12, "name", "peyman", "extra"]},
+    "hide_constraint_precise": {"some_key": [12, "name", "peyman", "extra"]} 
+}

--- a/tests/data/special_constraints/all_good1.json
+++ b/tests/data/special_constraints/all_good1.json
@@ -1,0 +1,4 @@
+{
+    "hide_constraint": {"some_key": [12, "name", "peyman"]},
+    "hide_constraint_precise": {"some_key": [12, "name", "peyman"]}
+}

--- a/tests/data/special_constraints/module.yaml
+++ b/tests/data/special_constraints/module.yaml
@@ -61,6 +61,27 @@ fields:
               key: string
               value: bool
 
+    ThreeItemsTable:
+        constraints:
+            - type: map
+              value:
+                  type: all
+                  items: [list, {type: range, min: 3, max: 3}]
+
+    ThreeItemsTablePrecise:
+        constraints:
+            - type: map
+              value:
+                  type: all
+                  hide: false
+                  name: three_item_constraint
+                  message: "Only three items are allowed."
+                  items:
+                      - list
+                      - type: range
+                        min: 3
+                        max: 3
+
 models:
     User:
         fields:
@@ -88,3 +109,8 @@ models:
             _meta: MetaField
             string_to_any: StringToAny
             string_to_bool: StringToBool
+
+    AllTest:
+        fields:
+            hide_constraint: ThreeItemsTable
+            hide_constraint_precise: ThreeItemsTablePrecise

--- a/tests/test_constraints.cpp
+++ b/tests/test_constraints.cpp
@@ -64,3 +64,13 @@ TEST(Constraints, MapConstraint) {
   assert_jsonfile_invalid(module, "MapTest", "data/special_constraints/map_bad2.json");
   assert_jsonfile_invalid(module, "MapTest", "data/special_constraints/map_bad3.json");
 }
+
+TEST(Constraints, AllConstraint) {
+  auto module = Module<JsonView>();
+
+  load_libyaml_module(module, "data/special_constraints/module.yaml");
+
+  assert_jsonfile_valid(module, "AllTest", "data/special_constraints/all_good1.json", true);
+  assert_jsonfile_invalid(module, "AllTest", "data/special_constraints/all_bad1.json", true);
+  assert_jsonfile_invalid(module, "AllTest", "data/special_constraints/all_bad2.json", true);
+}


### PR DESCRIPTION
# All Constraint

Introducing a new constraint that reads a list of constraints to simplify reading
multiple constraints should it be necessary.

NOTE: One might use `hide` attribute to decide if the constraint will forward its
children's results or yield its own constraint. This option is enabled by default.

```yaml
fields:
    Test:
        constraints:
            - type: all
              items:
                - list
                - type: range
                  min: 3
                  max: 4

    TestPrecise:
        constraints:
            - type: all
              hide: false
              message: "A list containing 3-4 items expected."
              items:
                - list
                - type: range
                  min: 3
                  max: 4
```
