### PR TITLE
Refactor: Rename Layer Concepts

### DIFF
--- a/include/garlic/constraints.h
+++ b/include/garlic/constraints.h
@@ -32,7 +32,7 @@ namespace garlic {
   template<typename ConstraintPtrType>
   std::vector<ConstraintResult>
   test_constraints(
-      const ReadableLayer auto& value,
+      const ViewLayer auto& value,
       const std::vector<ConstraintPtrType>& constraints,
       std::vector<ConstraintResult>& results) {
     for (const auto& constraint : constraints) {
@@ -47,7 +47,7 @@ namespace garlic {
 
   template<typename ConstraintPtrType, typename Callback>
   void test_constraints_first_failure(
-      const ReadableLayer auto& value,
+      const ViewLayer auto& value,
       std::vector<ConstraintPtrType> constraints,
       const Callback& cb
       ) {
@@ -60,14 +60,14 @@ namespace garlic {
   }
 
 
-  void set_constraint_properties(const ReadableLayer auto& value, ConstraintProperties& props) noexcept {
+  void set_constraint_properties(const ViewLayer auto& value, ConstraintProperties& props) noexcept {
     get_member(value, "fatal", [&props](const auto& item) { props.fatal = item.get_bool(); });
     get_member(value, "message", [&props](const auto& item) { props.message = item.get_cstr(); });
     get_member(value, "name", [&props](const auto& item) { props.name = item.get_cstr(); });
   }
 
 
-  template<garlic::ReadableLayer LayerType>
+  template<garlic::ViewLayer LayerType>
   class Constraint {
   public:
     explicit Constraint(ConstraintProperties&& props) : props_(std::move(props)) {}
@@ -132,7 +132,7 @@ namespace garlic {
   };
 
 
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class TypeConstraint : public Constraint<LayerType> {
   public:
 
@@ -180,7 +180,7 @@ namespace garlic {
   };
 
 
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class RangeConstraint : public Constraint<LayerType> {
   public:
     using SizeType = size_t;
@@ -228,7 +228,7 @@ namespace garlic {
   };
 
 
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class RegexConstraint : public Constraint<LayerType> {
   public:
 
@@ -253,7 +253,7 @@ namespace garlic {
   };
 
 
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class AnyConstraint : public Constraint<LayerType> {
   public:
 
@@ -280,7 +280,7 @@ namespace garlic {
   };
 
 
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class ListConstraint : public Constraint<LayerType> {
   public:
 
@@ -324,7 +324,7 @@ namespace garlic {
   };
 
 
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class TupleConstraint : public Constraint<LayerType> {
   public:
 
@@ -379,7 +379,7 @@ namespace garlic {
   };
 
 
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class MapConstraint : public Constraint<LayerType> {
   public:
     using ConstraintPtr = std::shared_ptr<Constraint<LayerType>>;
@@ -421,7 +421,7 @@ namespace garlic {
   };
 
 
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class AllConstraint : public Constraint<LayerType> {
   public:
 

--- a/include/garlic/layer.h
+++ b/include/garlic/layer.h
@@ -23,7 +23,7 @@ namespace garlic {
   template<typename T> using ConstMemberIterator = typename T::ConstMemberIterator;
   template<typename T> using MemberIterator = typename T::MemberIterator;
 
-  template<typename T> concept ReadableLayer = std::copy_constructible<T> && requires(const T& t) {
+  template<typename T> concept ViewLayer = std::copy_constructible<T> && requires(const T& t) {
     typename ConstValueIterator<T>;
     typename ConstMemberIterator<T>;
 
@@ -53,7 +53,7 @@ namespace garlic {
     { t.get_object() } -> std::ranges::range;
   };
 
-  template<typename T> concept GarlicLayer = ReadableLayer<T> && requires(T t) {
+  template<typename T> concept RefLayer = ViewLayer<T> && requires(T t) {
     typename ValueIterator<T>;
     typename MemberIterator<T>;
 

--- a/include/garlic/models.h
+++ b/include/garlic/models.h
@@ -14,10 +14,10 @@
 
 namespace garlic {
 
-  template<garlic::ReadableLayer LayerType>
+  template<garlic::ViewLayer LayerType>
   class Field {
   public:
-    template<garlic::ReadableLayer> friend class Module;
+    template<garlic::ViewLayer> friend class Module;
 
     using ConstraintType = Constraint<LayerType>;
     using ConstraintPtr = std::shared_ptr<ConstraintType>;
@@ -67,10 +67,10 @@ namespace garlic {
   };
 
 
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class Model {
   public:
-    template<garlic::ReadableLayer> friend class Module;
+    template<garlic::ViewLayer> friend class Module;
 
     using Layer = LayerType;
     using FieldType = Field<LayerType>;
@@ -167,7 +167,7 @@ namespace garlic {
 
 
   // Model Constraint
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class ModelConstraint : public Constraint<LayerType> {
   public:
     using ModelType = Model<LayerType>;
@@ -184,22 +184,22 @@ namespace garlic {
     std::shared_ptr<ModelType> model_;
   };
 
-  // Model Parsing From ReadableLayer
+  // Model Parsing From ViewLayer
   template<typename T> using ModelPropertiesOf = typename Model<T>::Properties;
   template<typename T> using FieldPropertiesOf = typename Field<T>::Properties;
   
-  template<ReadableLayer LayerType, typename...Args>
+  template<ViewLayer LayerType, typename...Args>
   std::shared_ptr<Field<LayerType>> make_field(Args&&... args) {
     return std::make_shared<Field<LayerType>>(std::forward<Args>(args)...);
   }
 
-  template<ReadableLayer LayerType, typename...Args>
+  template<ViewLayer LayerType, typename...Args>
   std::shared_ptr<Model<LayerType>> make_model(Args&&...args) {
     return std::make_shared<Model<LayerType>>(std::forward<Args>(args)...);
   }
 
 
-  template<ReadableLayer LayerType>
+  template<ViewLayer LayerType>
   class FieldConstraint : public Constraint<LayerType> {
   public:
     using FieldPtr = std::shared_ptr<Field<LayerType>>;

--- a/include/garlic/module.h
+++ b/include/garlic/module.h
@@ -8,7 +8,7 @@
 
 namespace garlic {
 
-  template<ReadableLayer Destination>
+  template<ViewLayer Destination>
   class Module {
   public:
     template <typename T> using MapOf = std::map<std::string, T>;
@@ -39,7 +39,7 @@ namespace garlic {
       fields_ = static_map;
     }
 
-    ParsingResult parse(const ReadableLayer auto& value) noexcept {
+    ParsingResult parse(const ViewLayer auto& value) noexcept {
       if (!value.is_object()) return {false};
       
       parse_context context;
@@ -133,7 +133,7 @@ namespace garlic {
           Module& module
       ) : context(context), module(module) {}
 
-      template<ReadableLayer Source, typename Callable>
+      template<ViewLayer Source, typename Callable>
       void parse_constraint(const Source& value, const Callable& cb) {
         module.parse_constraint(value, context, cb);
       }
@@ -151,7 +151,7 @@ namespace garlic {
       }
     };
 
-    void process_model_meta(ModelPropertiesOf<Destination>& props, const ReadableLayer auto& value) {
+    void process_model_meta(ModelPropertiesOf<Destination>& props, const ViewLayer auto& value) {
       get_member(value, "description", [&props](const auto& item) {
         props.meta.emplace("description", item.get_string());
       });
@@ -163,7 +163,7 @@ namespace garlic {
       });
     }
 
-    void process_model_inheritance(const ModelPtr& model, parse_context& context, const ReadableLayer auto& value) {
+    void process_model_inheritance(const ModelPtr& model, parse_context& context, const ViewLayer auto& value) {
       enum FieldStatus : uint8_t { lazy = 1, available = 2, exclude = 3 };
       struct field_info {
         FieldStatus status;
@@ -224,7 +224,7 @@ namespace garlic {
     }
 
     template<typename Callable>
-    void parse_model(std::string&& name, const ReadableLayer auto& value, parse_context& context, const Callable& cb) {
+    void parse_model(std::string&& name, const ViewLayer auto& value, parse_context& context, const Callable& cb) {
       auto ptr = std::make_shared<ModelType>(std::move(name));
       auto& props = ptr->properties_;
 
@@ -258,7 +258,7 @@ namespace garlic {
       return false;
     }
 
-    void process_field_meta(FieldPropertiesOf<Destination>& props, const ReadableLayer auto& value) {
+    void process_field_meta(FieldPropertiesOf<Destination>& props, const ViewLayer auto& value) {
       get_member(value, "meta", [&props](const auto& item) {
         for (const auto& member : item.get_object()) {
           props.meta.emplace(member.key.get_string(), member.value.get_string());
@@ -278,7 +278,7 @@ namespace garlic {
 
     template<typename SuccessCallable, typename FailCallable>
     void parse_field(
-        std::string&& name, const ReadableLayer auto& value,
+        std::string&& name, const ViewLayer auto& value,
         parse_context& context, const SuccessCallable& cb,
         const FailCallable& fcb
         ) noexcept {
@@ -380,7 +380,7 @@ namespace garlic {
       fields_[std::move(key)] = std::move(ptr);  // register the field.
     }
 
-    template<ReadableLayer Source, typename Callable>
+    template<ViewLayer Source, typename Callable>
     void parse_constraint(const Source& value, parse_context& context, const Callable& cb) noexcept {
       typedef ConstraintPtr (*ConstraintInitializer)(const Source&, parser);
       static const std::map<std::string, ConstraintInitializer> ctors = {

--- a/include/garlic/parsing/constraints.h
+++ b/include/garlic/parsing/constraints.h
@@ -10,9 +10,9 @@ namespace garlic::parsing {
 
   template<typename T> using ConstraintPtrOf = std::shared_ptr<Constraint<T>>;
 
-  template<ReadableLayer Destination, typename Parser>
+  template<ViewLayer Destination, typename Parser>
   static std::shared_ptr<Constraint<Destination>>
-  parse_any(const ReadableLayer auto& value, Parser parser) noexcept {
+  parse_any(const ViewLayer auto& value, Parser parser) noexcept {
     ConstraintProperties props {false};
     set_constraint_properties(value, props);
     std::vector<ConstraintPtrOf<Destination>> constraints;
@@ -23,9 +23,9 @@ namespace garlic::parsing {
   }
 
 
-  template<ReadableLayer Destination, typename Parser>
+  template<ViewLayer Destination, typename Parser>
   static ConstraintPtrOf<Destination>
-  parse_all(const ReadableLayer auto& value, Parser parser) noexcept {
+  parse_all(const ViewLayer auto& value, Parser parser) noexcept {
     ConstraintProperties props {false, ""};
     set_constraint_properties(value, props);
     std::vector<ConstraintPtrOf<Destination>> constraints;
@@ -40,9 +40,9 @@ namespace garlic::parsing {
   }
 
 
-  template<ReadableLayer Destination, typename Parser>
+  template<ViewLayer Destination, typename Parser>
   static ConstraintPtrOf<Destination>
-  parse_list(const ReadableLayer auto& value, Parser parser) noexcept {
+  parse_list(const ViewLayer auto& value, Parser parser) noexcept {
     ConstraintProperties props {true, "list_constraint"};
     set_constraint_properties(value, props);
     ConstraintPtrOf<Destination> constraint;
@@ -53,9 +53,9 @@ namespace garlic::parsing {
   }
 
 
-  template<ReadableLayer Destination, typename Parser>
+  template<ViewLayer Destination, typename Parser>
   static ConstraintPtrOf<Destination>
-  parse_tuple(const ReadableLayer auto& value, Parser parser) noexcept {
+  parse_tuple(const ViewLayer auto& value, Parser parser) noexcept {
     ConstraintProperties props {false, "tuple_constraint"};
     set_constraint_properties(value, props);
     std::vector<ConstraintPtrOf<Destination>> constraints;
@@ -70,9 +70,9 @@ namespace garlic::parsing {
   }
 
 
-  template<ReadableLayer Destination, typename Parser>
+  template<ViewLayer Destination, typename Parser>
   static ConstraintPtrOf<Destination>
-  parse_range(const ReadableLayer auto& value, Parser parser) noexcept {
+  parse_range(const ViewLayer auto& value, Parser parser) noexcept {
     typename RangeConstraint<Destination>::SizeType min;
     typename RangeConstraint<Destination>::SizeType max;
     get_member(value, "min", [&min](const auto& v) {
@@ -87,9 +87,9 @@ namespace garlic::parsing {
   }
 
 
-  template<ReadableLayer Destination, typename Parser>
+  template<ViewLayer Destination, typename Parser>
   static ConstraintPtrOf<Destination>
-  parse_regex(const ReadableLayer auto& value, Parser parser) noexcept {
+  parse_regex(const ViewLayer auto& value, Parser parser) noexcept {
     std::string pattern;
     ConstraintProperties props {false, "regex_constraint"};
     set_constraint_properties(value, props);
@@ -102,9 +102,9 @@ namespace garlic::parsing {
   }
 
 
-  template<ReadableLayer Destination, typename Parser>
+  template<ViewLayer Destination, typename Parser>
   static ConstraintPtrOf<Destination>
-  parse_field(const ReadableLayer auto& value, Parser parser) noexcept {
+  parse_field(const ViewLayer auto& value, Parser parser) noexcept {
     using FieldPtr = std::shared_ptr<Field<Destination>>;
     ConstraintProperties props {true};
     set_constraint_properties(value, props);
@@ -126,9 +126,9 @@ namespace garlic::parsing {
   }
 
 
-  template<ReadableLayer Destination, typename Parser>
+  template<ViewLayer Destination, typename Parser>
   static std::shared_ptr<Constraint<Destination>>
-  parse_map(const ReadableLayer auto& value, Parser parser) noexcept {
+  parse_map(const ViewLayer auto& value, Parser parser) noexcept {
     ConstraintProperties props {false, "map_constraint"};
     set_constraint_properties(value, props);
     ConstraintPtrOf<Destination> key_constraint;
@@ -141,10 +141,10 @@ namespace garlic::parsing {
   }
 
 
-  template<ReadableLayer Destination, typename ParserType>
+  template<ViewLayer Destination, typename ParserType>
   static void
   read_constraint(
-      const ReadableLayer auto& value,
+      const ViewLayer auto& value,
       ParserType& parser,
       const char* name,
       ConstraintPtrOf<Destination>& ptr) {
@@ -156,10 +156,10 @@ namespace garlic::parsing {
   }
 
   
-  template<ReadableLayer Destination, typename ParserType>
+  template<ViewLayer Destination, typename ParserType>
   static void
   read_constraints(
-      const ReadableLayer auto& value,
+      const ViewLayer auto& value,
       ParserType& parser,
       const char* name,
       std::vector<ConstraintPtrOf<Destination>>& container) {

--- a/include/garlic/utility.h
+++ b/include/garlic/utility.h
@@ -14,7 +14,7 @@
 
 namespace garlic {
 
-  template<ReadableLayer L1, ReadableLayer L2>
+  template<ViewLayer L1, ViewLayer L2>
   bool cmp_layers(const L1& layer1, const L2& layer2) {
     if (layer1.is_int() && layer2.is_int() && layer1.get_int() == layer2.get_int()) return true;
     else if (layer1.is_string() && layer2.is_string() && std::strcmp(layer1.get_cstr(), layer2.get_cstr()) == 0) {
@@ -84,7 +84,7 @@ namespace garlic {
   };
 
 
-  template<ReadableLayer LayerType, typename Callable>
+  template<ViewLayer LayerType, typename Callable>
   void resolve(const LayerType& value, std::string_view path, Callable cb) {
     lazy_string_splitter parts{path};
     auto cursor = std::make_unique<LayerType>(value);
@@ -120,13 +120,13 @@ namespace garlic {
 
 
   template<typename Callable>
-  void get_member(const ReadableLayer auto& value, const char* key, const Callable& cb) noexcept {
+  void get_member(const ViewLayer auto& value, const char* key, const Callable& cb) noexcept {
     if(auto it = value.find_member(key); it != value.end_member()) cb((*it).value);
   }
 
 
   template<typename Callable>
-  void get_member(const ReadableLayer auto& value, std::string_view key, const Callable& cb) noexcept {
+  void get_member(const ViewLayer auto& value, std::string_view key, const Callable& cb) noexcept {
     if(auto it = value.find_member(key); it != value.end_member()) cb((*it).value);
   }
 

--- a/tests/test_protocol.h
+++ b/tests/test_protocol.h
@@ -16,7 +16,7 @@
 #include <vector>
 
 
-template<garlic::ReadableLayer LayerType>
+template<garlic::ViewLayer LayerType>
 void test_readonly_string_value(const LayerType& value, const std::string& text) {
   ASSERT_TRUE(value.is_string());
 
@@ -28,30 +28,30 @@ void test_readonly_string_value(const LayerType& value, const std::string& text)
   ASSERT_TRUE(std_string_view == text);
 }
 
-template<garlic::ReadableLayer LayerType>
+template<garlic::ViewLayer LayerType>
 void test_readonly_int_value(const LayerType& value, int expectation) {
   ASSERT_TRUE(value.is_int());
   ASSERT_EQ(value.get_int(), expectation);
 }
 
-template<garlic::ReadableLayer LayerType>
+template<garlic::ViewLayer LayerType>
 void test_readonly_double_value(const LayerType& value, double expectation) {
   ASSERT_TRUE(value.is_double());
   ASSERT_EQ(value.get_double(), expectation);
 }
 
-template<garlic::ReadableLayer LayerType>
+template<garlic::ViewLayer LayerType>
 void test_readonly_bool_value(const LayerType& value, bool expectation) {
   ASSERT_TRUE(value.is_bool());
   ASSERT_EQ(value.get_bool(), expectation);
 }
 
-template<garlic::ReadableLayer LayerType>
+template<garlic::ViewLayer LayerType>
 void test_readonly_null_value(const LayerType& value) {
   ASSERT_TRUE(value.is_null());
 }
 
-template<garlic::ReadableLayer LayerType>
+template<garlic::ViewLayer LayerType>
 void test_readonly_list_range(const LayerType& value) {
   ASSERT_TRUE(value.is_list());
   auto it = value.begin_list();
@@ -62,7 +62,7 @@ void test_readonly_list_range(const LayerType& value) {
   ASSERT_EQ(it, value.end_list());
 }
 
-template<garlic::ReadableLayer LayerType>
+template<garlic::ViewLayer LayerType>
 void test_readonly_object_range(const LayerType& value) {
   ASSERT_TRUE(value.is_object());
   auto it = value.begin_member();
@@ -75,7 +75,7 @@ void test_readonly_object_range(const LayerType& value) {
 
 // Tests for writing.
 
-template<garlic::GarlicLayer LayerType>
+template<garlic::RefLayer LayerType>
 void test_full_string_value(LayerType& value) {
   std::string origin = "This is a very smoky test just to show if we have some string support.";
   std::string_view view = std::string_view{origin};
@@ -89,19 +89,19 @@ void test_full_string_value(LayerType& value) {
   test_readonly_string_value(value, origin);
 }
 
-template<garlic::GarlicLayer LayerType>
+template<garlic::RefLayer LayerType>
 void test_full_int_value(LayerType& value) {
   value.set_int(170);
   test_readonly_int_value(value, 170);
 }
 
-template<garlic::GarlicLayer LayerType>
+template<garlic::RefLayer LayerType>
 void test_full_double_value(LayerType& value) {
   value.set_double(170.189);
   test_readonly_double_value(value, 170.189);
 }
 
-template<garlic::GarlicLayer LayerType>
+template<garlic::RefLayer LayerType>
 void test_full_bool_value(LayerType& value) {
   value.set_bool(true);
   test_readonly_bool_value(value, true);
@@ -110,13 +110,13 @@ void test_full_bool_value(LayerType& value) {
   test_readonly_bool_value(value, false);
 }
 
-template<garlic::GarlicLayer LayerType>
+template<garlic::RefLayer LayerType>
 void test_full_null_value(LayerType& value) {
   value.set_null();
   test_readonly_null_value(value);
 }
 
-template<garlic::GarlicLayer LayerType>
+template<garlic::RefLayer LayerType>
 void test_full_list_value(LayerType& value) {
   value.set_list();
   value.push_back("string");
@@ -152,7 +152,7 @@ void test_full_list_value(LayerType& value) {
   ASSERT_EQ(value.begin_list(), value.end_list());
 }
 
-template<garlic::GarlicLayer LayerType>
+template<garlic::RefLayer LayerType>
 void test_full_object_value(LayerType& value) {
   value.set_object();
   value.add_member("null");
@@ -216,7 +216,7 @@ void test_full_object_value(LayerType& value) {
   ASSERT_EQ((*const_it).value.get_double(), 12);
 }
 
-template<garlic::GarlicLayer LayerType>
+template<garlic::RefLayer LayerType>
 void test_full_basic_assignment(LayerType& value) {
   value = 12.5;
   test_readonly_double_value(value, 12.5);
@@ -228,7 +228,7 @@ void test_full_basic_assignment(LayerType& value) {
   test_readonly_bool_value(value, false);
 }
 
-template<garlic::GarlicLayer LayerType>
+template<garlic::RefLayer LayerType>
 void test_full_layer(LayerType&& value) {
   test_full_string_value(value);
   test_full_double_value(value);

--- a/tests/test_utility.h
+++ b/tests/test_utility.h
@@ -28,7 +28,7 @@ void print_constraint_result(const garlic::ConstraintResult& result, int level=0
 void assert_field_constraint_result(const garlic::ConstraintResult& results, const char* name);
 void assert_constraint_result(const garlic::ConstraintResult& results, const char* name, const char* message);
 
-template<garlic::ReadableLayer LayerType>
+template<garlic::ViewLayer LayerType>
 void print_constraints(const garlic::FieldPropertiesOf<LayerType>& props) {
   bool first = true;
   for (const auto& c : props.constraints) {
@@ -38,7 +38,7 @@ void print_constraints(const garlic::FieldPropertiesOf<LayerType>& props) {
   }
 }
 
-template<garlic::ReadableLayer LayerType>
+template<garlic::ViewLayer LayerType>
 void assert_field_constraints(const garlic::Field<LayerType>& field, NameQueue names) {
   for(const auto& constraint : field.get_properties().constraints) {
     ASSERT_STREQ(constraint->get_name().data(), names.front().data());


### PR DESCRIPTION
# Rename Concept Layers

In `layer.h`, the following name changes have happened:

`ReadableLayer` -> `ViewLayer`

`GarlicLayer` -> `RefLayer`
