### PR TITLE
Feature: Use garlic::text instead of other string types.

### DIFF
--- a/include/garlic/adapters/libyaml/document.h
+++ b/include/garlic/adapters/libyaml/document.h
@@ -110,12 +110,7 @@ namespace garlic::adapters::libyaml {
 
     ConstMemberIterator begin_member() const { return ConstMemberIterator({node_->data.mapping.pairs.start, doc_}); }
     ConstMemberIterator end_member() const { return ConstMemberIterator({node_->data.mapping.pairs.top, doc_}); }
-    ConstMemberIterator find_member(const char* key) const {
-      return std::find_if(this->begin_member(), this->end_member(), [&key](const auto& item) {
-        return strcmp(key, item.key.get_cstr()) == 0;
-      });
-    }
-    ConstMemberIterator find_member(std::string_view key) const {
+    ConstMemberIterator find_member(text key) const {
       return std::find_if(this->begin_member(), this->end_member(), [&key](const auto& item) {
         return key.compare(item.key.get_cstr()) == 0;
       });

--- a/include/garlic/adapters/rapidjson/document.h
+++ b/include/garlic/adapters/rapidjson/document.h
@@ -205,6 +205,9 @@ namespace garlic::adapters::rapidjson {
       void set_string(text value) {
         value_.SetString(value.data(), value.size(), allocator_);
       }
+      void set_string(string_ref value) {
+        value_.SetString(::rapidjson::StringRef(value.data(), value.size()));
+      }
       void set_int(int value) { value_.SetInt(value); }
       void set_double(double value) { value_.SetDouble(value); }
       void set_bool(bool value) { value_.SetBool(value); }
@@ -266,6 +269,9 @@ namespace garlic::adapters::rapidjson {
       }
       void push_back(text value) {
         push_back(ProviderValueType().SetString(value.data(), value.size(), allocator_));
+      }
+      void push_back(string_ref value) {
+        push_back(ProviderValueType().SetString(::rapidjson::StringRef(value.data(), value.size())));
       }
       void push_back(int value) { push_back(ProviderValueType(value)); }
       void push_back(double value) { push_back(ProviderValueType(value)); }

--- a/include/garlic/adapters/rapidjson/document.h
+++ b/include/garlic/adapters/rapidjson/document.h
@@ -10,6 +10,9 @@
 #include "rapidjson/reader.h"
 #include "rapidjson/writer.h"
 
+#include "reader.h"
+#include "writer.h"
+
 
 namespace garlic::adapters::rapidjson {
 
@@ -497,10 +500,10 @@ namespace garlic::adapters::rapidjson {
       ::rapidjson::FileWriteStream os(file, write_buffer, length);
       if (pretty) {
         auto writer = ::rapidjson::PrettyWriter<::rapidjson::FileWriteStream>(os);
-        dump(writer, source);
+        write(writer, source);
       } else {
         auto writer = ::rapidjson::Writer<::rapidjson::FileWriteStream>(os);
-        dump(writer, source);
+        write(writer, source);
       }
     }
 

--- a/include/garlic/adapters/rapidjson/document.h
+++ b/include/garlic/adapters/rapidjson/document.h
@@ -354,7 +354,7 @@ namespace garlic::adapters::rapidjson {
 
       template<typename Key>
       void add_member(Key key) {
-        this->add_member(this->build_key(key));
+        this->add_member(this->build_key(key), ProviderValueType());
       }
 
       template<typename Key>
@@ -422,7 +422,7 @@ namespace garlic::adapters::rapidjson {
         return value;
       }
 
-      inline ProviderValueType build_key(const string_ref& key) const noexcept {
+      inline ProviderValueType build_key(string_ref key) const noexcept {
         auto value = ProviderValueType();
         value.SetString(::rapidjson::StringRef(key.data(), key.size()));
         return value;
@@ -490,11 +490,11 @@ namespace garlic::adapters::rapidjson {
   static inline const char* dump(JsonType&& source, bool pretty = false) {
     ::rapidjson::StringBuffer buffer;
     if (pretty) {
-      source.get_inner_value().Accept(
-          ::rapidjson::PrettyWriter<::rapidjson::StringBuffer>(buffer));
+      auto handler = ::rapidjson::PrettyWriter<::rapidjson::StringBuffer>(buffer);
+      source.get_inner_value().Accept(handler);
     } else {
-      source.get_inner_value().Accept(
-          ::rapidjson::Writer<::rapidjson::StringBuffer>(buffer));
+      auto handler = ::rapidjson::Writer<::rapidjson::StringBuffer>(buffer);
+      source.get_inner_value().Accept(handler);
     }
     return buffer.GetString();
   }

--- a/include/garlic/adapters/rapidjson/writer.h
+++ b/include/garlic/adapters/rapidjson/writer.h
@@ -6,7 +6,7 @@
 #include "rapidjson/writer.h"
 
 namespace garlic::adapters::rapidjson {
-    
+
   //! Use a rapidjson writer to dump a readable layer.
   //! \tparam Writer a rapidjson Writer
   //! \tparam Layer any readable layer conforming to garlic::ViewLayer

--- a/include/garlic/adapters/rapidjson/writer.h
+++ b/include/garlic/adapters/rapidjson/writer.h
@@ -14,18 +14,18 @@ namespace garlic::adapters::rapidjson {
   //! \param layer the layer to dump.
   template<typename Writer, GARLIC_VIEW Layer>
   static void
-  dump(Writer&& writer, Layer&& layer) {
+  write(Writer&& writer, Layer&& layer) {
     if (layer.is_object()) {
       writer.StartObject();
       for (const auto& pair : layer.get_object()) {
         writer.Key(pair.key.get_cstr());
-        dump(writer, pair.value);
+        write(writer, pair.value);
       }
       writer.EndObject();
     } else if (layer.is_list()) {
       writer.StartArray();
       for (const auto& item : layer.get_list()) {
-        dump(writer, item);
+        write(writer, item);
       }
       writer.EndArray();
     } else if (layer.is_bool()) {

--- a/include/garlic/containers.h
+++ b/include/garlic/containers.h
@@ -24,7 +24,7 @@ namespace garlic {
     copy,
   };
 
-  //! A container for storing small strings that can manage both act as a view and as an owner.
+  //! A container for storing small strings that can either act as a view or as an owner.
   /*!
    * \code
    * text view = "Some Text";  // only a view.

--- a/include/garlic/containers.h
+++ b/include/garlic/containers.h
@@ -43,8 +43,8 @@ namespace garlic {
     explicit basic_string_ref(
         const std::basic_string<Ch>& data) : data_(data.data()), size_(data.size()) {}
 
-    explicit constexpr basic_string_ref(const basic_string_ref& value) : data_(value.data_), size_(value.size_) {};
-    explicit constexpr basic_string_ref(basic_string_ref&& value) : data_(value.data_), size_(value.size_) {};
+    constexpr basic_string_ref(const basic_string_ref& value) : data_(value.data_), size_(value.size_) {};
+    constexpr basic_string_ref(basic_string_ref&& value) : data_(value.data_), size_(value.size_) {};
 
     constexpr const Ch* data() const { return data_; }
     constexpr SizeType size() const { return size_; }
@@ -136,6 +136,9 @@ namespace garlic {
     }
     inline basic_text view() const noexcept {
       return basic_text(data_, size_, text_type::reference);
+    }
+    inline basic_string_ref<Ch> string_ref() const noexcept {
+      return basic_string_ref<Ch>(data_, size_);
     }
 
     constexpr ~basic_text() { destroy(); }

--- a/include/garlic/containers.h
+++ b/include/garlic/containers.h
@@ -43,8 +43,8 @@ namespace garlic {
     explicit basic_string_ref(
         const std::basic_string<Ch>& data) : data_(data.data()), size_(data.size()) {}
 
-    explicit constexpr basic_string_ref(const basic_string_ref&) = default;
-    explicit constexpr basic_string_ref(basic_string_ref&&) = default;
+    explicit constexpr basic_string_ref(const basic_string_ref& value) : data_(value.data_), size_(value.size_) {};
+    explicit constexpr basic_string_ref(basic_string_ref&& value) : data_(value.data_), size_(value.size_) {};
 
     constexpr const Ch* data() const { return data_; }
     constexpr SizeType size() const { return size_; }

--- a/include/garlic/containers.h
+++ b/include/garlic/containers.h
@@ -24,6 +24,34 @@ namespace garlic {
     copy,
   };
 
+  template<typename Ch, typename SizeType = unsigned>
+  class basic_string_ref {
+  private:
+    const Ch* data_;
+    SizeType size_;
+
+  public:
+    explicit constexpr basic_string_ref(const Ch* data) : data_(data) {
+      size_ = strlen(data);
+    }
+
+    explicit constexpr basic_string_ref(const Ch* data, SizeType size) : data_(data), size_(size) {}
+
+    explicit constexpr basic_string_ref(
+        const std::basic_string_view<Ch>& data) : data_(data.data()), size_(data.size()) {}
+
+    explicit basic_string_ref(
+        const std::basic_string<Ch>& data) : data_(data.data()), size_(data.size()) {}
+
+    explicit constexpr basic_string_ref(const basic_string_ref&) = default;
+    explicit constexpr basic_string_ref(basic_string_ref&&) = default;
+
+    constexpr const Ch* data() const { return data_; }
+    constexpr SizeType size() const { return size_; }
+  };
+
+  using string_ref = basic_string_ref<char>;
+
   //! A container for storing small strings that can either act as a view or as an owner.
   /*!
    * \code
@@ -64,6 +92,10 @@ namespace garlic {
 
     constexpr basic_text(
         const std::basic_string_view<Ch>& value,
+        text_type type = text_type::reference) : basic_text(value.data(), value.size(), type) {}
+
+    constexpr basic_text(
+        const basic_string_ref<Ch>& value,
         text_type type = text_type::reference) : basic_text(value.data(), value.size(), type) {}
 
     constexpr basic_text(

--- a/include/garlic/containers.h
+++ b/include/garlic/containers.h
@@ -133,6 +133,14 @@ namespace garlic {
     inline constexpr SizeType size() const noexcept { return size_; }
     inline constexpr bool empty() const noexcept { return !size_; }
     inline constexpr bool is_view() const noexcept { return type_ == text_type::reference; }
+    
+    inline int compare(const char* value) {
+      return strncmp(value, data_, size_);
+    }
+
+    inline int compare(const basic_text& value) {
+      return strncmp(value.data_, data_, size_);
+    }
 
     constexpr static inline basic_text no_text() noexcept {
       return basic_text("");

--- a/include/garlic/layer.h
+++ b/include/garlic/layer.h
@@ -205,7 +205,6 @@ namespace garlic {
     { t.begin_member() } -> forward_pair_iterator;
     { t.end_member() } -> forward_pair_iterator;
     { t.find_member(std::declval<text>()) } -> forward_pair_iterator;
-    //{ t.find_member(std::declval<std::string_view>()) } -> forward_pair_iterator;
     { t.get_object() } -> std::ranges::range;
 
     { t.get_view() };
@@ -230,7 +229,6 @@ namespace garlic {
     { t.begin_member() } -> forward_pair_iterator;
     { t.end_member() } -> forward_pair_iterator;
     { t.find_member(std::declval<text>()) } -> forward_pair_iterator;
-    //{ t.find_member(std::declval<std::string_view>()) } -> forward_pair_iterator;
     { t.get_object() } -> std::ranges::range;
 
     /* TODO:  <29-01-21, Peyman> Add a constraint to support pushing T. */

--- a/include/garlic/layer.h
+++ b/include/garlic/layer.h
@@ -7,6 +7,7 @@
  */
 
 #include "garlic.h"
+#include "containers.h"
 
 #ifdef GARLIC_USE_CONCEPTS
 #define GARLIC_VIEW garlic::ViewLayer
@@ -203,8 +204,8 @@ namespace garlic {
 
     { t.begin_member() } -> forward_pair_iterator;
     { t.end_member() } -> forward_pair_iterator;
-    { t.find_member(std::declval<const char*>()) } -> forward_pair_iterator;
-    { t.find_member(std::declval<std::string_view>()) } -> forward_pair_iterator;
+    { t.find_member(std::declval<text>()) } -> forward_pair_iterator;
+    //{ t.find_member(std::declval<std::string_view>()) } -> forward_pair_iterator;
     { t.get_object() } -> std::ranges::range;
 
     { t.get_view() };
@@ -214,9 +215,7 @@ namespace garlic {
     typename ValueIteratorOf<T>;
     typename MemberIteratorOf<T>;
 
-    { t.set_string(std::declval<const char*>()) };
-    { t.set_string(std::declval<std::string>()) };
-    { t.set_string(std::declval<std::string_view>()) };
+    { t.set_string(std::declval<text>()) };
     { t.set_bool(std::declval<bool>()) };
     { t.set_int(std::declval<int>()) };
     { t.set_double(std::declval<double>()) };
@@ -230,14 +229,15 @@ namespace garlic {
 
     { t.begin_member() } -> forward_pair_iterator;
     { t.end_member() } -> forward_pair_iterator;
-    { t.find_member(std::declval<const char*>()) } -> forward_pair_iterator;
-    { t.find_member(std::declval<std::string_view>()) } -> forward_pair_iterator;
+    { t.find_member(std::declval<text>()) } -> forward_pair_iterator;
+    //{ t.find_member(std::declval<std::string_view>()) } -> forward_pair_iterator;
     { t.get_object() } -> std::ranges::range;
 
     /* TODO:  <29-01-21, Peyman> Add a constraint to support pushing T. */
     { t.clear() };
     { t.push_back() };
     { t.push_back(std::declval<const char*>()) };
+    { t.push_back(std::declval<text>()) };
     { t.push_back(std::declval<bool>()) };
     { t.push_back(std::declval<int>()) };
     { t.push_back(std::declval<double>()) };
@@ -246,13 +246,14 @@ namespace garlic {
     { t.erase(std::declval<ValueIteratorOf<T>>()) };
     { t.erase(std::declval<ValueIteratorOf<T>>(), std::declval<ValueIteratorOf<T>>()) };
 
-    { t.add_member(std::declval<const char*>()) };
-    { t.add_member(std::declval<const char*>(), std::declval<const char*>()) };
-    { t.add_member(std::declval<const char*>(), std::declval<bool>()) };
-    { t.add_member(std::declval<const char*>(), std::declval<int>()) };
-    { t.add_member(std::declval<const char*>(), std::declval<double>()) };
-    { t.add_member_builder(std::declval<const char*>(), std::declval<void(*)(T)>()) };
-    { t.remove_member(std::declval<const char*>()) };
+    { t.add_member(std::declval<text>()) };
+    { t.add_member(std::declval<text>(), std::declval<const char*>()) };
+    { t.add_member(std::declval<text>(), std::declval<text>()) };
+    { t.add_member(std::declval<text>(), std::declval<bool>()) };
+    { t.add_member(std::declval<text>(), std::declval<int>()) };
+    { t.add_member(std::declval<text>(), std::declval<double>()) };
+    { t.add_member_builder(std::declval<text>(), std::declval<void(*)(T)>()) };
+    { t.remove_member(std::declval<text>()) };
     { t.erase_member(std::declval<MemberIteratorOf<T>>()) };
 
     { t.get_reference() };

--- a/notes.txt
+++ b/notes.txt
@@ -3,11 +3,8 @@
   When making the Python module, take a look at this:
   https://github.com/python-rapidjson/python-rapidjson
 
-  2. Add optional get_string_length and get_list_length methods.
   5. Attempt to add support for JSON Schema so we can produce some metrics.
   6. Python module test run.
 
 Make sure resolve doesn't use make_unique and it just relied on get_view() functions repeatedly.
-Make sure add_member supports various different string types
-Make sure std::string_view has specific meaning and that is string referencce.
 Make sure libyaml doesn't store temporary string in there.

--- a/tests/adapters/rapidjson/performance.cpp
+++ b/tests/adapters/rapidjson/performance.cpp
@@ -1,3 +1,5 @@
+#include "garlic/adapters/rapidjson/reader.h"
+#include "rapidjson/filereadstream.h"
 #include <benchmark/benchmark.h>
 #include <rapidjson/document.h>
 #include <garlic/garlic.h>
@@ -65,5 +67,33 @@ static void BM_CreateJsonDocument_Garlic(benchmark::State& state) {
 
 BENCHMARK(BM_CreateJsonDocument_Garlic);
 BENCHMARK(BM_CreateJsonDocument_Native);
+
+
+static void BM_ReadDocument(benchmark::State& state) {
+  for (auto _ : state) {
+    auto file = fopen("data/test.json", "r");
+    rapidjson::Document doc;
+    char buffer[256];
+    auto input_stream = rapidjson::FileReadStream(file, buffer, sizeof(buffer));
+    doc.ParseStream(input_stream);
+    fclose(file);
+  }
+}
+
+static void BM_ReadLayer(benchmark::State& state) {
+  for (auto _ : state) {
+    auto file = fopen("data/test.json", "r");
+    rapidjson::Reader reader;
+    rapidjson::Document doc;
+    char buffer[256];
+    auto input_stream = rapidjson::FileReadStream(file, buffer, sizeof(buffer));
+    auto handler = make_handler(JsonRef(doc));
+    reader.Parse(input_stream, handler);
+    fclose(file);
+  }
+}
+
+BENCHMARK(BM_ReadDocument);
+BENCHMARK(BM_ReadLayer);
 
 BENCHMARK_MAIN();

--- a/tests/test_protocol.h
+++ b/tests/test_protocol.h
@@ -123,6 +123,7 @@ void test_full_list_value(LayerType& value) {
   
   test_readonly_list_range(value);
   auto it = value.begin_list();
+  ASSERT_TRUE((*it).is_string());
   ASSERT_STREQ((*it).get_cstr(), "string");
   it++;
   ASSERT_EQ((*it).get_int(), 25);


### PR DESCRIPTION
- update comment.
- Switch to garlic::text to simplify strings.
- Add optional support for string_ref
- Support for string ref in rapidjson
- Added LayerHandler support for rapidjson
- Finalized support for reading and writing using RapidJSON
- Rename dump to write to avoid confusion.
- update notes.txt
